### PR TITLE
Support JUnit reports generated by Gradle and failsafe plugin

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'Junit Report to Annotations'
 description: 'Create an annotation of the test run summaryand also list first n failed tests as seporate annotations'
 branding:
-  icon: 'box'  
+  icon: 'box'
   color: 'green'
 inputs:
   access-token:
@@ -10,7 +10,7 @@ inputs:
   path:
     description: 'glob to junit xml files'
     required: true
-    default: 'target/surefire-reports/*.xml'
+    default: '**/TEST-*.xml'
   includeSummary:
     description: 'include summary annotation'
     required: true
@@ -19,7 +19,7 @@ inputs:
     description: 'max number of failed tests to include'
     require: true
     default: 10
-  testSrcPath: 
+  testSrcPath:
     description: 'path to test source'
     required: true
     default: 'src/test/java/'


### PR DESCRIPTION
This action is currently made for the surefire maven plugin by setting
`/target/surefire-reports/*.xml` as the default glob to JUnit XML files.

However, the documentation of the plugin (https://maven.apache.org/surefire/maven-surefire-report-plugin/) state that XML report file are named `TEST-*.xml`.

Using this kind of default glob makes the action works seamlessly with the maven failsafe plugin (see https://maven.apache.org/surefire/maven-failsafe-plugin/) and Gradle.

Moreover having the `**` pattern allows to detect tests in submodules or without the standard archetype of maven java project.