### PR TITLE
Add tests on annotation production and fix "undefined" in annotations

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,9 @@ class TestSummary {
       start_column: 0,
       end_column: 0,
       annotation_level: "failure",
+      title: testcase.$.name,
       message: TestSummary.formatFailureMessage(testcase),
+      raw_details: testcase.failure[0]._ || 'No details'
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -26,37 +26,10 @@ async function forEach(target, process, ...args) {
       followSymbolicLinks: false,
     });
 
-    let numTests = 0;
-    let numSkipped = 0;
-    let numFailed = 0;
-    let numErrored = 0;
-    let testDuration = 0;
-
-    let annotations = [];
+    let testSummary = new TestSummary();
 
     async function processTestSuite(testsuite, file) {
-      testDuration += Number(testsuite.$.time);
-      numTests += Number(testsuite.$.tests);
-      numErrored += Number(testsuite.$.errors);
-      numFailed += Number(testsuite.$.failures);
-      numSkipped += Number(testsuite.$.skipped);
-      testFunction = async (testcase) => {
-        if (testcase.failure) {
-          if (annotations.length < numFailures) {
-            let { filePath, line } = await findTestLocation(file, testcase);
-            annotations.push({
-              path: filePath,
-              start_line: line,
-              end_line: line,
-              start_column: 0,
-              end_column: 0,
-              annotation_level: "failure",
-              message: `Junit test ${testcase.name} failed ${testcase.failure.message}`,
-            });
-          }
-        }
-      };
-      await forEach(testsuite.testcase, testFunction);
+      await testSummary.handleTestSuite(testsuite, file, numFailures);
     }
 
     for await (const file of globber.globGenerator()) {
@@ -68,7 +41,7 @@ async function forEach(target, process, ...args) {
       await forEach(json.testsuite, processTestSuite, file);
     }
 
-    const annotation_level = numFailed + numErrored > 0 ? "failure" : "notice";
+    const annotation_level = testSummary.isFailedOrErrored() ? "failure" : "notice";
     const annotation = {
       path: "test",
       start_line: 0,
@@ -76,17 +49,18 @@ async function forEach(target, process, ...args) {
       start_column: 0,
       end_column: 0,
       annotation_level,
-      message: `Junit Results ran ${numTests} in ${testDuration} seconds ${numErrored} Errored, ${numFailed} Failed, ${numSkipped} Skipped`,
+      message: testSummary.toFormattedMessage(),
     };
 
-    const conclusion = annotations.length === 0 ? "success" : "failure";
-    annotations = [annotation, ...annotations];
+    const conclusion = testSummary.annotations.length === 0 ? "success" : "failure";
+    testSummary.annotations = [annotation, ...testSummary.annotations];
 
     const pullRequest = github.context.payload.pull_request;
     const link = (pullRequest && pullRequest.html_url) || github.context.ref;
     const status = "completed";
     const head_sha =
       (pullRequest && pullRequest.head.sha) || github.context.sha;
+    const annotations = testSummary.annotations;
 
     const createCheckRequest = {
       ...github.context.repo,
@@ -96,7 +70,7 @@ async function forEach(target, process, ...args) {
       conclusion,
       output: {
         title: name,
-        summary: `Junit Results ran ${numTests} in ${testDuration} seconds ${numErrored} Errored, ${numFailed} Failed, ${numSkipped} Skipped`,
+        summary: testSummary.toFormattedMessage(),
         annotations,
       },
     };
@@ -107,6 +81,84 @@ async function forEach(target, process, ...args) {
     core.setFailed(error.message);
   }
 })();
+
+class TestSummary {
+
+  numTests = 0;
+  numSkipped = 0;
+  numFailed = 0;
+  numErrored = 0;
+  testDuration = 0;
+  annotations = [];
+
+  async handleTestSuite(testsuite, file, maxNumFailures) {
+    this.testDuration += Number(testsuite.$.time);
+    this.numTests += Number(testsuite.$.tests);
+    this.numErrored += Number(testsuite.$.errors);
+    this.numFailed += Number(testsuite.$.failures);
+    this.numSkipped += Number(testsuite.$.skipped);
+
+    let testFunction = async (testcase) => {
+      if (testcase.failure) {
+        if (this.annotations.length < maxNumFailures) {
+          let { filePath, line } = await findTestLocation(file, testcase);
+          this.annotations.push({
+            path: filePath,
+            start_line: line,
+            end_line: line,
+            start_column: 0,
+            end_column: 0,
+            annotation_level: "failure",
+            message: `Junit test ${testcase.name} failed ${testcase.failure.message}`,
+          });
+        }
+      }
+    };
+    await forEach(testsuite.testcase, testFunction);
+  }
+
+  isFailedOrErrored() {
+    return this.numFailed > 0 || this.numErrored > 0;
+  }
+
+  toFormattedMessage() {
+    return `Junit Results ran ${this.numTests} in ${this.testDuration} seconds ${this.numErrored} Errored, ${this.numFailed} Failed, ${this.numSkipped} Skipped`;
+  }
+
+}
+
+async function readJUnitReport(data, file, testSummary) {
+  async function processTestSuite(testsuite, file) {
+    testDuration += Number(testsuite.$.time);
+    numTests += Number(testsuite.$.tests);
+    numErrored += Number(testsuite.$.errors);
+    numFailed += Number(testsuite.$.failures);
+    numSkipped += Number(testsuite.$.skipped);
+    testFunction = async (testcase) => {
+      if (testcase.failure) {
+        if (annotations.length < numFailures) {
+          let { filePath, line } = await findTestLocation(file, testcase);
+          annotations.push({
+            path: filePath,
+            start_line: line,
+            end_line: line,
+            start_column: 0,
+            end_column: 0,
+            annotation_level: "failure",
+            message: `Junit test ${testcase.name} failed ${testcase.failure.message}`,
+          });
+        }
+      }
+    };
+    await forEach(testsuite.testcase, testFunction);
+  }
+
+  let json = await parser.parseStringPromise(data);
+  await forEach(json.testsuites, (testSuites) =>
+      forEach(testSuites.testsuite, processTestSuite, file)
+  );
+  await forEach(json.testsuite, processTestSuite, file);
+}
 
 /**
  * Find the file and the line of the test method that is specified in the given test case.

--- a/index.js
+++ b/index.js
@@ -99,11 +99,11 @@ class TestSummary {
       return;
     }
 
-    if (this.annotations.length >= this.maxNumFailures) {
+    if (this.maxNumFailures !== -1 && this.annotations.length >= this.maxNumFailures) {
       return;
     }
 
-    let {filePath, line} = await findTestLocation(file, testcase);
+    const {filePath, line} = await module.exports.findTestLocation(file, testcase);
 
     this.annotations.push({
       path: filePath,
@@ -112,8 +112,17 @@ class TestSummary {
       start_column: 0,
       end_column: 0,
       annotation_level: "failure",
-      message: `Junit test ${testcase.name} failed ${testcase.failure.message}`,
+      message: TestSummary.formatFailureMessage(testcase),
     });
+  }
+
+  static formatFailureMessage(testcase) {
+    const failure = testcase.failure[0];
+    if (failure.$ && failure.$.message) {
+      return `Junit test ${testcase.$.name} failed ${failure.$.message}`;
+    } else {
+      return `Junit test ${testcase.$.name} failed`;
+    }
   }
 
   isFailedOrErrored() {

--- a/index.js
+++ b/index.js
@@ -79,11 +79,13 @@ class TestSummary {
   annotations = [];
 
   async handleTestSuite(testsuite, file) {
-    this.testDuration += Number(testsuite.$.time);
-    this.numTests += Number(testsuite.$.tests);
-    this.numErrored += Number(testsuite.$.errors);
-    this.numFailed += Number(testsuite.$.failures);
-    this.numSkipped += Number(testsuite.$.skipped);
+    if (testsuite.$) {
+      this.testDuration += Number(testsuite.$.time) || 0;
+      this.numTests += Number(testsuite.$.tests) || 0;
+      this.numErrored += Number(testsuite.$.errors) || 0;
+      this.numFailed += Number(testsuite.$.failures) || 0;
+      this.numSkipped += Number(testsuite.$.skipped) || 0;
+    }
 
     if (testsuite.testcase) {
       for await (const testcase of testsuite.testcase) {
@@ -231,3 +233,4 @@ async function findTestLocation(testReportFile, testcase) {
 
 module.exports.findTestLocation = findTestLocation;
 module.exports.readTestSuites = readTestSuites;
+module.exports.TestSummary = TestSummary;

--- a/index.test.js
+++ b/index.test.js
@@ -275,7 +275,8 @@ describe('TestSummary', () => {
         failure: [{
           $: {
             message: 'dummyMessage'
-          }
+          },
+          _: 'detailed description of failure'
         }]
       };
 
@@ -293,11 +294,13 @@ describe('TestSummary', () => {
         start_column: 0,
         end_column: 0,
         annotation_level: 'failure',
+        title: 'dummyTest',
         message: 'Junit test dummyTest failed dummyMessage',
+        raw_details: 'detailed description of failure'
       }]);
     });
 
-    it('should handle no message in failure', async () => {
+    it('should handle no message and no content in failure', async () => {
       const testcase = {
         $: {
           name: 'dummyTest'
@@ -319,7 +322,9 @@ describe('TestSummary', () => {
         start_column: 0,
         end_column: 0,
         annotation_level: 'failure',
+        title: 'dummyTest',
         message: 'Junit test dummyTest failed',
+        raw_details: 'No details'
       }]);
     });
   });

--- a/index.test.js
+++ b/index.test.js
@@ -207,6 +207,44 @@ describe('readTestSuites', () => {
   });
 });
 
+describe('TestSummary', () => {
+  describe('handleTestSuite', () => {
+    it('should be initialized with empty summary', () => {
+      const testSummary = new index.TestSummary();
+
+      expect(testSummary.testDuration).toBe(0);
+      expect(testSummary.numTests).toBe(0);
+      expect(testSummary.numErrored).toBe(0);
+      expect(testSummary.numFailed).toBe(0);
+      expect(testSummary.numSkipped).toBe(0);
+      expect(testSummary.annotations).toStrictEqual([]);
+    });
+
+    it('should ignore missing values', async () => {
+      const testSummary = new index.TestSummary();
+
+      await testSummary.handleTestSuite({
+        $: {
+          time: "1",
+          tests: "2",
+          errors: "3",
+          failures: "4",
+          skipped: "5"
+        }
+      }, 'file');
+
+      await testSummary.handleTestSuite({$:{}}, 'file');
+      await testSummary.handleTestSuite({}, 'file');
+
+      expect(testSummary.testDuration).toBe(1);
+      expect(testSummary.numTests).toBe(2);
+      expect(testSummary.numErrored).toBe(3);
+      expect(testSummary.numFailed).toBe(4);
+      expect(testSummary.numSkipped).toBe(5);
+    });
+  });
+});
+
 async function addFile(filePath, content) {
   filePath = "tmp/" + filePath;
   let dirname = path.dirname(filePath);

--- a/test/TEST-ActionTest.xml
+++ b/test/TEST-ActionTest.xml
@@ -1,6 +1,79 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="com.dummy.ActionTest" tests="1" skipped="0" failures="0" errors="0" timestamp="2020-07-04T07:45:48" hostname="localhost" time="0.001">
-    <properties/>
-    <system-out><![CDATA[]]></system-out>
-    <system-err><![CDATA[]]></system-err>
-</testsuite>
+<testsuites>
+    <testsuite name="org.dummy.DummyTest" tests="3" failures="1" errors="1"
+               timestamp="2020-07-21T19:20:12" hostname="dummy" time="0.132">
+        <testcase name="test1" classname="org.dummy.DummyTest" time="0.028"/>
+        <testcase
+                name="test2_givenAPrecondition_ThenItShouldDoSomething" classname="org.dummy.DummyTest" time="0.054">
+            <failure
+                    message="java.lang.AssertionError: &#10;Expected not same:&lt;Mock for Object, hashCode: 1210565765&gt;" type="java.lang.AssertionError">java.lang.AssertionError:
+                Expected not same:&lt;Mock for Object, hashCode: 1210565765&gt;
+                at org.dummy.DummyTest.test2_givenAPrecondition_ThenItShouldDoSomething(DummyTest.kt:61)
+                at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+                at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+                at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+                at java.base/java.lang.reflect.Method.invoke(Method.java:566)
+                at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
+                at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
+                at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
+                at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
+                at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
+                at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
+                at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
+                at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
+                at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
+                at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
+                at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
+                at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
+                at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
+                at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
+                at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
+                at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
+                at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
+                at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
+                at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
+                at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
+                at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
+                at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+                at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+                at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+                at java.base/java.lang.reflect.Method.invoke(Method.java:566)
+                at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
+                at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
+                at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
+                at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
+                at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
+                at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:119)
+                at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+                at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+                at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+                at java.base/java.lang.reflect.Method.invoke(Method.java:566)
+                at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
+                at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
+                at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:182)
+                at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:164)
+                at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:414)
+                at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
+                at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
+                at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+                at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+                at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
+                at java.base/java.lang.Thread.run(Thread.java:834)
+            </failure>
+        </testcase>
+        <testcase classname="test.yml"
+                  name="doing an action given a precondition should result in something" time="0">¤
+            <failure type="failure"><![CDATA[
+ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean bibendum, ligula et congue
+ vulputate, sem leo tempor turpis, auctor aliquam dolor neque blandit arcu. Aenean scelerisque, orci
+ id vehicula interdum, purus risus bibendum nulla, ac pellentesque felis mauris at orci. Aenean nec
+ est at urna blandit bibendum sit amet sed libero. Vestibulum vestibulum, dui a tristique imperdiet,
+ odio elit tincidunt mi, id molestie risus eros quis neque. Duis hendrerit turpis a orci tempor
+ aliquam. Maecenas dignissim odio in sem sagittis tempus. Morbi ac molestie ante. Pellentesque
+ condimentum pellentesque egestas.
+ ]]></failure>
+        </testcase>
+    </testsuite>
+    <testsuite name="org.dummy.DummyTest2">
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
This PR brings unit tests on:
- deserialization of JUnit XML report to JSON
- production of annotations
- edge cases with missing parameters are handled

This add simulated failures in the embedded JUnit report to automatically generate example of the plugin in its own GitHub Action run (see https://github.com/TurpIF/junit-report-annotations-action/runs/899761676?check_suite_focus=true for instance).

By adding the test, few bugs were fixed:
- #12 : there was "undefined" printed in annotations, making this GA almost not usable.
- #13 : by setting `numFailures` to `-1`, there is no limit of annotations
- #14 partially : test name is displayed, details of failure are added

For #14, the line and file are still when not using java-like structure (with tests under src). 