### PR TITLE
Update to Node 20 runner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,5 +24,5 @@ inputs:
     require: true
     default: "Junit Results"
 runs:
-  using: "node16"
+  using: "node20"
   main: "index.js"


### PR DESCRIPTION
To resolve warnings like:
```
Node.js 16 actions are deprecated.
Please update the following actions to use Node.js 20: ashley-taylor/junit-report-annotations-action@1.4.
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```